### PR TITLE
Add `-Werror` to the list of `CXXFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ publish: publish-rust
 TWSEARCH_VERSION=$(shell git describe --tags)
 
 # MAKEFLAGS += -j
-CXXFLAGS = -O3 -Wextra -Wall -pedantic -std=c++17 -g -Wsign-compare
+CXXFLAGS = -O3 -Wextra -Werror -Wall -pedantic -std=c++17 -g -Wsign-compare
 FLAGS = -DTWSEARCH_VERSION=${TWSEARCH_VERSION} -DUSE_PTHREADS -DHAVE_FFSLL
 LDFLAGS = -lpthread
 


### PR DESCRIPTION
How strict do we want to be in this repo?

Before
======

    $ make build
    ...
    g++ -I./src/cpp/cityhash/src -c -O3 -Wextra -Wall -pedantic -std=c++17 -g -Wsign-compare -DTWSEARCH_VERSION=v0.6.4-50-gdc1ec4e -DUSE_PTHREADS -DHAVE_FFSLL src/cpp/coset.cpp -o build/cpp/coset.o
    src/cpp/coset.cpp: In function ‘int cosetcallback(setval, const std::vector<int>&, int, int)’:
    src/cpp/coset.cpp:111:11: warning: array subscript 1 is outside array bounds of ‘setval [1]’ [-Warray-bounds]
      111 |     domove(pd, pos, moves[i], *(&pos + 1));
          |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/cpp/coset.cpp:98:26: note: at offset 8 into object ‘pos’ of size 8
       98 | int cosetcallback(setval pos, const vector<int> &moves, int d, int id) {
          |                   ~~~~~~~^~~
    ...
    g++ -O3 -Wextra -Wall -pedantic -std=c++17 -g -Wsign-compare -o build/bin/twsearch build/cpp/antipode.o build/cpp/calcsymm.o build/cpp/canon.o build/cpp/cmdlineops.o build/cpp/filtermoves.o build/cpp/findalgo.o build/cpp/generatingset.o build/cpp/god.o build/cpp/index.o build/cpp/parsemoves.o build/cpp/prunetable.o build/cpp/puzdef.o build/cpp/readksolve.o build/cpp/solve.o build/cpp/test.o build/cpp/threads.o build/cpp/twsearch.o build/cpp/util.o build/cpp/workchunks.o build/cpp/rotations.o build/cpp/orderedgs.o build/cpp/ffi/ffi_api.o build/cpp/ffi/wasm_api.o build/cpp/city.o build/cpp/coset.o build/cpp/descsets.o build/cpp/ordertree.o build/cpp/unrotate.o build/cpp/shorten.o -lpthread

After
======

    $ make build
    ...
    src/cpp/coset.cpp: In function ‘int cosetcallback(setval, const std::vector<int>&, int, int)’:
    src/cpp/coset.cpp:111:11: error: array subscript 1 is outside array bounds of ‘setval [1]’ [-Werror=array-bounds]
      111 |     domove(pd, pos, moves[i], *(&pos + 1));
          |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/cpp/coset.cpp:98:26: note: at offset 8 into object ‘pos’ of size 8
       98 | int cosetcallback(setval pos, const vector<int> &moves, int d, int id) {
          |                   ~~~~~~~^~~
    cc1plus: all warnings being treated as errors
    make: *** [Makefile:110: build/cpp/coset.o] Error 1