### PR TITLE
Prevent adjacent `U` and `D` moves in `baby_fto`scrambles.

### DIFF
--- a/src/rs-wasm/wasm_api.rs
+++ b/src/rs-wasm/wasm_api.rs
@@ -1,11 +1,8 @@
-use std::sync::Arc;
-
 use cubing::alg::Move;
 use cubing::kpuzzle::{KPattern, KPatternData, KPuzzle};
 use serde::{Deserialize, Serialize};
-use twsearch::_internal::cli::args::{CustomGenerators, Generators, MetricEnum};
+use twsearch::_internal::cli::args::{CustomGenerators, Generators};
 use twsearch::_internal::search::idf_search::{IDFSearch, IndividualSearchOptions};
-use twsearch::_internal::search::search_logger::SearchLogger;
 use wasm_bindgen::prelude::*;
 
 use twsearch::scramble::{random_scramble_for_event, Event};
@@ -68,12 +65,9 @@ pub fn wasmTwsearch(
 
     let idfs = <IDFSearch<KPuzzle>>::try_new(
         kpuzzle.clone(),
-        target_pattern,
         generators.enumerate_moves_for_kpuzzle(&kpuzzle),
-        Arc::new(SearchLogger::default()),
-        &MetricEnum::Hand,
-        true,
-        None,
+        target_pattern,
+        Default::default(),
     );
     let mut idfs = idfs.map_err(|e| e.description)?;
 

--- a/src/rs/_cli/commands/canonical_algs.rs
+++ b/src/rs/_cli/commands/canonical_algs.rs
@@ -18,8 +18,8 @@ pub fn canonical_algs(args: &CanonicalAlgsArgs) -> Result<(), CommandError> {
         false,
     )?;
 
-    let canonical_fsm =
-        CanonicalFSM::try_new(kpuzzle, search_generators).expect("Expected to work!");
+    let canonical_fsm = CanonicalFSM::try_new(kpuzzle, search_generators, Default::default())
+        .expect("Expected to work!");
     dbg!(canonical_fsm);
 
     Ok(())

--- a/src/rs/_cli/serve/serve.rs
+++ b/src/rs/_cli/serve/serve.rs
@@ -11,12 +11,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use twsearch::_internal::cli::args::CustomGenerators;
 use twsearch::_internal::cli::args::Generators;
-use twsearch::_internal::cli::args::MetricEnum;
 use twsearch::_internal::cli::args::ServeArgsForIndividualSearch;
 use twsearch::_internal::cli::args::ServeClientArgs;
 use twsearch::_internal::cli::args::ServeCommandArgs;
 use twsearch::_internal::errors::CommandError;
 use twsearch::_internal::search::idf_search::IDFSearch;
+use twsearch::_internal::search::idf_search::IDFSearchConstructionOptions;
 use twsearch::_internal::search::idf_search::IndividualSearchOptions;
 use twsearch::_internal::search::search_logger::SearchLogger;
 
@@ -87,19 +87,20 @@ fn solve_pattern(
     };
     let mut search = match <IDFSearch<KPuzzle>>::try_new(
         kpuzzle.clone(),
-        target_pattern,
         Generators::Custom(CustomGenerators {
             moves: move_list.clone(),
             algs: vec![],
         })
         .enumerate_moves_for_kpuzzle(&kpuzzle),
-        search_logger,
-        &MetricEnum::Hand, // TODO
-        match args_for_individual_search.client_args {
-            Some(client_args) => client_args.random_start == Some(true),
-            None => false,
+        target_pattern,
+        IDFSearchConstructionOptions {
+            search_logger,
+            random_start: match args_for_individual_search.client_args {
+                Some(client_args) => client_args.random_start == Some(true),
+                None => false,
+            },
+            ..Default::default()
         },
-        None,
     ) {
         Ok(search) => search,
         Err(e) => return Response::text(e.description).with_status_code(400),

--- a/src/rs/_internal/canonical_fsm/canonical_fsm.rs
+++ b/src/rs/_internal/canonical_fsm/canonical_fsm.rs
@@ -1,5 +1,8 @@
 use std::{collections::HashMap, marker::PhantomData, ops::BitAndAssign};
 
+use cityhasher::HashSet;
+use cubing::alg::QuantumMove;
+
 use crate::{
     _internal::{
         errors::SearchError, puzzle_traits::puzzle_traits::SemiGroupActionPuzzle,
@@ -8,7 +11,7 @@ use crate::{
     whole_number_newtype,
 };
 
-use super::search_generators::SearchGenerators;
+use super::search_generators::{MoveTransformationInfo, SearchGenerators};
 
 const MAX_NUM_MOVE_CLASSES: usize = usize::BITS as usize;
 
@@ -74,11 +77,38 @@ pub struct CanonicalFSM<TPuzzle: SemiGroupActionPuzzle> {
     phantom_data: PhantomData<TPuzzle>,
 }
 
+#[derive(Debug, Default)]
+pub struct CanonicalFSMConstructionOptions {
+    forbid_transitions_by_quantums_either_direction: HashSet<(QuantumMove, QuantumMove)>,
+}
+
+impl CanonicalFSMConstructionOptions {
+    fn is_transition_forbidden<TPuzzle: SemiGroupActionPuzzle>(
+        &self,
+        move1_info: &MoveTransformationInfo<TPuzzle>,
+        move2_info: &MoveTransformationInfo<TPuzzle>,
+    ) -> bool {
+        self.forbid_transitions_by_quantums_either_direction
+            .contains(&(
+                move1_info.r#move.quantum.as_ref().clone(),
+                move2_info.r#move.quantum.as_ref().clone(),
+            ))
+            || self
+                .forbid_transitions_by_quantums_either_direction
+                .contains(&(
+                    move2_info.r#move.quantum.as_ref().clone(),
+                    move1_info.r#move.quantum.as_ref().clone(),
+                ))
+    }
+}
+
 impl<TPuzzle: SemiGroupActionPuzzle> CanonicalFSM<TPuzzle> {
     // TODO: Return a more specific error.
+    /// Pass `Default::default()` as for `options` when no options are needed.
     pub fn try_new(
         tpuzzle: TPuzzle,
-        generators: SearchGenerators<TPuzzle>,
+        generators: SearchGenerators<TPuzzle>, // TODO: make this a field in the options?
+        options: CanonicalFSMConstructionOptions,
     ) -> Result<CanonicalFSM<TPuzzle>, SearchError> {
         let num_move_classes = generators.by_move_class.len();
         if num_move_classes > MAX_NUM_MOVE_CLASSES {
@@ -100,10 +130,13 @@ impl<TPuzzle: SemiGroupActionPuzzle> CanonicalFSM<TPuzzle> {
             let i = MoveClassIndex(i);
             for j in 0..num_move_classes {
                 let j = MoveClassIndex(j);
+                let move1_info = &generators.by_move_class.at(i)[0];
+                let move2_info = &generators.by_move_class.at(i)[1];
                 if !tpuzzle.do_moves_commute(
                     &generators.by_move_class.at(i)[0],
                     &generators.by_move_class.at(j)[0],
-                ) {
+                ) || options.is_transition_forbidden(move1_info, move2_info)
+                {
                     commutes[*i] &= MoveClassMask(!(1 << *j));
                     commutes[*j] &= MoveClassMask(!(1 << *i));
                 }

--- a/src/rs/_internal/canonical_fsm/canonical_fsm.rs
+++ b/src/rs/_internal/canonical_fsm/canonical_fsm.rs
@@ -1,6 +1,9 @@
-use std::{collections::HashMap, marker::PhantomData, ops::BitAndAssign};
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+    ops::BitAndAssign,
+};
 
-use cityhasher::HashSet;
 use cubing::alg::QuantumMove;
 
 use crate::{
@@ -79,7 +82,7 @@ pub struct CanonicalFSM<TPuzzle: SemiGroupActionPuzzle> {
 
 #[derive(Debug, Default)]
 pub struct CanonicalFSMConstructionOptions {
-    forbid_transitions_by_quantums_either_direction: HashSet<(QuantumMove, QuantumMove)>,
+    pub forbid_transitions_by_quantums_either_direction: HashSet<(QuantumMove, QuantumMove)>,
 }
 
 impl CanonicalFSMConstructionOptions {
@@ -131,11 +134,9 @@ impl<TPuzzle: SemiGroupActionPuzzle> CanonicalFSM<TPuzzle> {
             for j in 0..num_move_classes {
                 let j = MoveClassIndex(j);
                 let move1_info = &generators.by_move_class.at(i)[0];
-                let move2_info = &generators.by_move_class.at(i)[1];
-                if !tpuzzle.do_moves_commute(
-                    &generators.by_move_class.at(i)[0],
-                    &generators.by_move_class.at(j)[0],
-                ) || options.is_transition_forbidden(move1_info, move2_info)
+                let move2_info = &generators.by_move_class.at(j)[0];
+                if !tpuzzle.do_moves_commute(move1_info, move2_info)
+                    || options.is_transition_forbidden(move1_info, move2_info)
                 {
                     commutes[*i] &= MoveClassMask(!(1 << *j));
                     commutes[*j] &= MoveClassMask(!(1 << *i));

--- a/src/rs/_internal/cli/args.rs
+++ b/src/rs/_internal/cli/args.rs
@@ -364,6 +364,7 @@ pub struct MetricArgs {
 impl Default for MetricArgs {
     fn default() -> Self {
         Self {
+            // TODO: deduplicate with `IDFSearchConstructionOptions`
             metric: MetricEnum::Hand,
         }
     }

--- a/src/rs/_internal/gods_algorithm/gods_algorithm_table.rs
+++ b/src/rs/_internal/gods_algorithm/gods_algorithm_table.rs
@@ -81,7 +81,11 @@ impl GodsAlgorithmSearch {
             quantum_metric,
             false,
         )?;
-        let canonical_fsm = CanonicalFSM::try_new(kpuzzle.clone(), search_generators.clone())?;
+        let canonical_fsm = CanonicalFSM::try_new(
+            kpuzzle.clone(),
+            search_generators.clone(),
+            Default::default(),
+        )?;
 
         let cached_inverses = IndexedVec::new(
             search_generators

--- a/src/rs/_internal/search/idf_search.rs
+++ b/src/rs/_internal/search/idf_search.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::_internal::{
     canonical_fsm::{
-        canonical_fsm::{CanonicalFSM, CanonicalFSMState, CANONICAL_FSM_START_STATE},
+        canonical_fsm::{
+            CanonicalFSM, CanonicalFSMConstructionOptions, CanonicalFSMState,
+            CANONICAL_FSM_START_STATE,
+        },
         search_generators::SearchGenerators,
     },
     cli::args::MetricEnum,
@@ -192,6 +195,7 @@ pub struct IDFSearchConstructionOptions {
     pub metric: MetricEnum,
     pub random_start: bool,
     pub min_prune_table_size: Option<usize>,
+    pub canonical_fsm_construction_options: CanonicalFSMConstructionOptions,
 }
 
 impl Default for IDFSearchConstructionOptions {
@@ -201,6 +205,7 @@ impl Default for IDFSearchConstructionOptions {
             metric: MetricEnum::Hand,
             random_start: Default::default(),
             min_prune_table_size: Default::default(),
+            canonical_fsm_construction_options: Default::default(),
         }
     }
 }
@@ -225,7 +230,7 @@ impl<
         let canonical_fsm = CanonicalFSM::try_new(
             tpuzzle.clone(),
             search_generators.clone(),
-            Default::default(),
+            options.canonical_fsm_construction_options,
         )?; // TODO: avoid a clone
         let api_data = Arc::new(IDFSearchAPIData {
             search_generators,

--- a/src/rs/_internal/search/idf_search.rs
+++ b/src/rs/_internal/search/idf_search.rs
@@ -203,7 +203,11 @@ impl<
     ) -> Result<Self, SearchError> {
         let search_generators =
             SearchGenerators::try_new(&tpuzzle, generator_moves, metric, random_start)?;
-        let canonical_fsm = CanonicalFSM::try_new(tpuzzle.clone(), search_generators.clone())?; // TODO: avoid a clone
+        let canonical_fsm = CanonicalFSM::try_new(
+            tpuzzle.clone(),
+            search_generators.clone(),
+            Default::default(),
+        )?; // TODO: avoid a clone
         let api_data = Arc::new(IDFSearchAPIData {
             search_generators,
             canonical_fsm,

--- a/src/rs/experimental_lib_api/search_api.rs
+++ b/src/rs/experimental_lib_api/search_api.rs
@@ -4,7 +4,9 @@ use crate::_internal::{
     cli::args::{SearchCommandOptionalArgs, VerbosityLevel},
     errors::CommandError,
     search::{
-        idf_search::{IDFSearch, IndividualSearchOptions, SearchSolutions},
+        idf_search::{
+            IDFSearch, IDFSearchConstructionOptions, IndividualSearchOptions, SearchSolutions,
+        },
         search_logger::SearchLogger,
     },
 };
@@ -50,20 +52,22 @@ pub fn search(
 
     let mut idf_search = <IDFSearch<KPuzzle>>::try_new(
         kpuzzle.clone(),
-        target_pattern,
         search_command_optional_args
             .generator_args
             .parse()
             .enumerate_moves_for_kpuzzle(kpuzzle),
-        Arc::new(SearchLogger {
-            verbosity: search_command_optional_args
-                .verbosity_args
-                .verbosity
-                .unwrap_or(VerbosityLevel::Error),
-        }),
-        &search_command_optional_args.metric_args.metric,
-        search_command_optional_args.search_args.random_start,
-        None,
+        target_pattern,
+        IDFSearchConstructionOptions {
+            search_logger: Arc::new(SearchLogger {
+                verbosity: search_command_optional_args
+                    .verbosity_args
+                    .verbosity
+                    .unwrap_or(VerbosityLevel::Error),
+            }),
+            metric: search_command_optional_args.metric_args.metric,
+            random_start: search_command_optional_args.search_args.random_start,
+            ..Default::default()
+        },
     )?;
 
     let solutions = idf_search.search(

--- a/src/rs/experimental_lib_api/simple_mask_multiphase_search.rs
+++ b/src/rs/experimental_lib_api/simple_mask_multiphase_search.rs
@@ -8,7 +8,7 @@ use cubing::{
 use crate::_internal::{
     errors::SearchError,
     search::{
-        idf_search::{IDFSearch, IndividualSearchOptions},
+        idf_search::{IDFSearch, IDFSearchConstructionOptions, IndividualSearchOptions},
         mask_pattern::apply_mask,
         search_logger::SearchLogger,
     },
@@ -52,12 +52,12 @@ impl SimpleMaskMultiphaseSearch {
                 };
                 let Ok(idfs) = IDFSearch::<KPuzzle>::try_new(
                     kpuzzle.clone(),
-                    target_pattern,
                     phase_info.generator_moves.clone(),
-                    search_logger.clone(),
-                    &crate::_internal::cli::args::MetricEnum::Hand,
-                    false,
-                    None,
+                    target_pattern,
+                    IDFSearchConstructionOptions {
+                        search_logger: search_logger.clone(),
+                        ..Default::default()
+                    },
                 ) else {
                     return Err(SearchError {
                         description: format!(

--- a/src/rs/scramble/puzzles/baby_fto.rs
+++ b/src/rs/scramble/puzzles/baby_fto.rs
@@ -3,7 +3,9 @@ use rand::{seq::SliceRandom, thread_rng};
 
 use crate::{
     _internal::search::{
-        idf_search::IndividualSearchOptions, move_count::MoveCount, prune_table_trait::Depth,
+        idf_search::{IDFSearch, IndividualSearchOptions},
+        move_count::MoveCount,
+        prune_table_trait::Depth,
     },
     scramble::{
         randomize::OrbitRandomizationConstraints,
@@ -22,15 +24,25 @@ pub fn scramble_baby_fto() -> Alg {
     let kpuzzle = baby_fto_kpuzzle();
     let filter_generator_moves = move_list_from_vec(vec!["U", "L", "F", "R"]);
     let mut filtered_search = <FilteredSearch>::new(
-        kpuzzle,
-        filter_generator_moves,
-        None,
-        kpuzzle.default_pattern(),
+        IDFSearch::try_new(
+            kpuzzle.clone(),
+            filter_generator_moves,
+            kpuzzle.default_pattern(),
+            Default::default(),
+        )
+        .unwrap(),
     );
 
     let generator_moves = move_list_from_vec(vec!["U", "L", "F", "R", "D"]);
-    let mut search =
-        <FilteredSearch>::new(kpuzzle, generator_moves, None, kpuzzle.default_pattern());
+    let mut search = <FilteredSearch>::new(
+        IDFSearch::try_new(
+            kpuzzle.clone(),
+            generator_moves,
+            kpuzzle.default_pattern(),
+            Default::default(),
+        )
+        .unwrap(),
+    );
 
     loop {
         let mut scramble_pattern = kpuzzle.default_pattern();

--- a/src/rs/scramble/puzzles/baby_fto.rs
+++ b/src/rs/scramble/puzzles/baby_fto.rs
@@ -1,11 +1,16 @@
-use cubing::alg::{parse_alg, Alg};
+use std::collections::HashSet;
+
+use cubing::alg::{parse_alg, Alg, QuantumMove};
 use rand::{seq::SliceRandom, thread_rng};
 
 use crate::{
-    _internal::search::{
-        idf_search::{IDFSearch, IndividualSearchOptions},
-        move_count::MoveCount,
-        prune_table_trait::Depth,
+    _internal::{
+        canonical_fsm::canonical_fsm::CanonicalFSMConstructionOptions,
+        search::{
+            idf_search::{IDFSearch, IDFSearchConstructionOptions, IndividualSearchOptions},
+            move_count::MoveCount,
+            prune_table_trait::Depth,
+        },
     },
     scramble::{
         randomize::OrbitRandomizationConstraints,
@@ -39,7 +44,15 @@ pub fn scramble_baby_fto() -> Alg {
             kpuzzle.clone(),
             generator_moves,
             kpuzzle.default_pattern(),
-            Default::default(),
+            IDFSearchConstructionOptions {
+                canonical_fsm_construction_options: CanonicalFSMConstructionOptions {
+                    forbid_transitions_by_quantums_either_direction: HashSet::from([(
+                        QuantumMove::new("U", None),
+                        QuantumMove::new("D", None),
+                    )]),
+                },
+                ..Default::default()
+            },
         )
         .unwrap(),
     );
@@ -74,8 +87,6 @@ pub fn scramble_baby_fto() -> Alg {
                 },
             );
         }
-
-        dbg!(&scramble_pattern);
 
         if let Some(alg) = filtered_search.filter(&scramble_pattern, MoveCount(5)) {
             eprintln!("Skipping due to short solution: {}", alg);

--- a/src/rs/scramble/puzzles/big_cubes.rs
+++ b/src/rs/scramble/puzzles/big_cubes.rs
@@ -33,7 +33,8 @@ impl<TPuzzle: SemiGroupActionPuzzle> ScrambleInfo<TPuzzle> {
     pub fn new(tpuzzle: &TPuzzle, moves: Vec<Move>) -> Self {
         let generators =
             SearchGenerators::try_new(tpuzzle, moves, &MetricEnum::Hand, false).unwrap();
-        let canonical_fsm = CanonicalFSM::try_new(tpuzzle.clone(), generators.clone()).unwrap();
+        let canonical_fsm =
+            CanonicalFSM::try_new(tpuzzle.clone(), generators.clone(), Default::default()).unwrap();
         Self {
             generators,
             canonical_fsm,

--- a/src/rs/scramble/puzzles/cube2x2x2.rs
+++ b/src/rs/scramble/puzzles/cube2x2x2.rs
@@ -1,7 +1,7 @@
 use cubing::{alg::Alg, puzzles::cube2x2x2_kpuzzle};
 
 use crate::{
-    _internal::search::move_count::MoveCount,
+    _internal::search::{idf_search::IDFSearch, move_count::MoveCount},
     scramble::{
         puzzles::static_move_list::{add_random_suffixes_from, static_parsed_opt_list},
         randomize::{ConstraintForFirstPiece, OrbitRandomizationConstraints},
@@ -16,20 +16,25 @@ pub fn scramble_2x2x2() -> Alg {
 
     #[allow(non_snake_case)] // Move meanings are case sensitive.
     let mut filtered_search_L_B_D = <FilteredSearch>::new(
-        kpuzzle,
-        move_list_from_vec(vec!["L", "B", "D"]),
-        None,
-        kpuzzle.default_pattern(),
+        IDFSearch::try_new(
+            kpuzzle.clone(),
+            move_list_from_vec(vec!["L", "B", "D"]),
+            kpuzzle.default_pattern(),
+            Default::default(),
+        )
+        .unwrap(),
     );
 
     #[allow(non_snake_case)] // Move meanings are case sensitive.
     let mut filtered_search_U_L_F_R = <FilteredSearch>::new(
-        kpuzzle,
-        move_list_from_vec(vec!["U", "L", "F", "R"]),
-        None,
-        kpuzzle.default_pattern(),
+        IDFSearch::try_new(
+            kpuzzle.clone(),
+            move_list_from_vec(vec!["U", "L", "F", "R"]),
+            kpuzzle.default_pattern(),
+            Default::default(),
+        )
+        .unwrap(),
     );
-
     loop {
         /* TODO: Since we don't yet have an API to solve to any orientation,
          * we perform the filtering search with a fixed orientation and then randomize the orientation for the returned scramble.

--- a/src/rs/scramble/puzzles/square1/solve.rs
+++ b/src/rs/scramble/puzzles/square1/solve.rs
@@ -7,9 +7,10 @@ use cubing::{
     kpuzzle::KPattern,
 };
 
+use crate::_internal::search::idf_search::IDFSearchConstructionOptions;
 use crate::{
     _internal::{
-        cli::args::{MetricEnum, VerbosityLevel},
+        cli::args::VerbosityLevel,
         errors::SearchError,
         search::{
             idf_search::{IDFSearch, IndividualSearchOptions},
@@ -45,16 +46,16 @@ pub(crate) fn solve_square1(pattern: &KPattern) -> Result<Alg, SearchError> {
         .full_pattern_to_phase_coordinate(&kpuzzle.default_pattern())
         .unwrap();
     let mut phase1_idfs = IDFSearch::<Square1Phase1Puzzle>::try_new(
-        square1_phase1_puzzle,
-        phase1_target_pattern,
+        square1_phase1_puzzle.clone(),
         generator_moves.clone(),
-        SearchLogger {
-            verbosity: VerbosityLevel::Info,
-        }
-        .into(),
-        &MetricEnum::Hand,
-        false,
-        None,
+        phase1_target_pattern,
+        IDFSearchConstructionOptions {
+            search_logger: SearchLogger {
+                verbosity: VerbosityLevel::Info,
+            }
+            .into(),
+            ..Default::default()
+        },
     )
     .unwrap();
 
@@ -101,15 +102,9 @@ pub(crate) fn solve_square1(pattern: &KPattern) -> Result<Alg, SearchError> {
         .unwrap();
     let mut phase2_idfs = IDFSearch::<Square1Phase2Puzzle>::try_new(
         square1_phase2_puzzle.clone(),
-        phase2_target_pattern,
         generator_moves.clone(),
-        SearchLogger {
-            verbosity: VerbosityLevel::Warning,
-        }
-        .into(),
-        &MetricEnum::Hand,
-        false,
-        None,
+        phase2_target_pattern,
+        Default::default(),
     )
     .unwrap();
 


### PR DESCRIPTION
Adds an `forbid_transitions_by_quantums_either_direction` option to the FSM constructor. This should probably be generalized, but it allows avoiding adjacent `U` and `D` moves for `baby_fto` for now.