### PR TITLE
Change Square-1 phase 2 to use smaller coordinate tables using clever math.

### DIFF
--- a/src/rs/_internal/search/coordinates/phase_coordinate_puzzle.rs
+++ b/src/rs/_internal/search/coordinates/phase_coordinate_puzzle.rs
@@ -163,11 +163,11 @@ where
         }
 
         // TODO: place this behind `SearchLogger`.
-        eprintln!(
-            "[PhaseCoordinatePuzzle] {} has {} patterns.",
-            TSemanticCoordinate::phase_name(),
-            index_to_semantic_coordinate.len()
-        );
+        // eprintln!(
+        //     "[PhaseCoordinatePuzzle] {} has {} patterns.",
+        //     TSemanticCoordinate::phase_name(),
+        //     index_to_semantic_coordinate.len()
+        // );
 
         let mut move_application_table: IndexedVec<
             PhaseCoordinateIndex<Self>,

--- a/src/rs/scramble/puzzles/square1/phase1.rs
+++ b/src/rs/scramble/puzzles/square1/phase1.rs
@@ -42,11 +42,7 @@ impl PatternValidityChecker<KPuzzle> for Phase1Checker {
         assert_eq!(orbit_info.name.0, "WEDGES");
 
         for slot in SLOTS_THAT_ARE_AFTER_SLICES {
-            let value = unsafe {
-                pattern
-                    .packed_orbit_data()
-                    .get_raw_piece_or_permutation_value(orbit_info, slot)
-            };
+            let value = pattern.get_piece(orbit_info, slot);
 
             // TODO: consider removing this lookup. We know that the wedge values are only 0, 1, or
             // 2 during this phase.

--- a/src/rs/scramble/puzzles/square1/phase2.rs
+++ b/src/rs/scramble/puzzles/square1/phase2.rs
@@ -1,25 +1,38 @@
-use cubing::kpuzzle::{KPattern, KPuzzle};
+use cubing::{
+    alg::parse_alg,
+    kpuzzle::{KPattern, KPuzzle},
+};
 
 use crate::{
     _internal::{
-        canonical_fsm::search_generators::MoveTransformationInfo,
+        canonical_fsm::search_generators::{FlatMoveIndex, MoveTransformationInfo},
+        puzzle_traits::puzzle_traits::SemiGroupActionPuzzle,
         search::{
             coordinates::{
-                phase_coordinate_puzzle::SemanticCoordinate,
+                phase_coordinate_puzzle::{
+                    PhaseCoordinateConversionError, PhaseCoordinateIndex, PhaseCoordinatePuzzle,
+                    SemanticCoordinate,
+                },
                 triple_phase_coordinate_puzzle::{
                     TriplePhaseCoordinatePruneTable, TriplePhaseCoordinatePuzzle,
                 },
             },
-            idf_search::search_adaptations::SearchAdaptations,
+            idf_search::search_adaptations::{DefaultSearchAdaptations, SearchAdaptations},
             mask_pattern::apply_mask,
             pattern_validity_checker::{AlwaysValid, PatternValidityChecker},
-            prune_table_trait::Depth,
-            recursion_filter_trait::RecursionFilter,
+            prune_table_trait::{Depth, PruneTable},
+            recursion_filter_trait::{RecursionFilter, RecursionFilterNoOp},
         },
     },
-    scramble::puzzles::{
-        definitions::{square1_corners_kpattern, square1_edges_kpattern, square1_shape_kpattern},
-        square1::wedges::{WedgeType, WEDGE_TYPE_LOOKUP},
+    scramble::{
+        puzzles::{
+            definitions::{
+                square1_corners_kpattern, square1_edges_kpattern, square1_shape_kpattern,
+                square1_unbandaged_kpuzzle,
+            },
+            square1::wedges::{WedgeType, WEDGE_TYPE_LOOKUP},
+        },
+        scramble_search::move_list_from_vec,
     },
 };
 
@@ -144,38 +157,214 @@ impl SemanticCoordinate<KPuzzle> for Phase2CornersCoordinate {
     }
 }
 
-pub(crate) type Square1Phase2Puzzle = TriplePhaseCoordinatePuzzle<
-    KPuzzle,
-    Phase2ShapeCoordinate,
-    Phase2EdgesCoordinate,
-    Phase2CornersCoordinate,
->;
+// TODO: rename to "shape" and move this above edges and corners
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub(crate) struct Phase2EquatorCoordinate {
+    pub(crate) equator: KPattern,
+}
 
-impl RecursionFilter<Square1Phase2Puzzle> for Square1Phase2Puzzle {
-    fn keep_move(
-        move_transformation_info: &MoveTransformationInfo<Square1Phase2Puzzle>,
-        remaining_depth: Depth,
-    ) -> bool {
-        if remaining_depth > Depth(6) {
-            restrict_D_move(move_transformation_info)
-        } else {
-            true
+impl SemanticCoordinate<KPuzzle> for Phase2EquatorCoordinate {
+    fn phase_name() -> &'static str {
+        "Equator (Square-1 → phase 2)"
+    }
+
+    fn try_new(_kpuzzle: &KPuzzle, full_pattern: &KPattern) -> Option<Self> {
+        // TODO: this isn't a full validity check for scramble positions.
+        if !Phase2Checker::is_valid(full_pattern) {
+            return None;
         }
+
+        let phase_mask = square1_shape_kpattern(); // TODO: Store this with the coordinate lookup?
+        let Ok(masked_pattern) = apply_mask(full_pattern, phase_mask) else {
+            panic!("Mask application failed");
+        };
+
+        Some(Self {
+            equator: masked_pattern,
+        })
     }
 }
 
-pub(crate) struct Square1Phase2SearchAdaptations {}
+// TODO: generalize this, similar to how `TriplePhaseCoordinatePuzzle` does.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Square1Phase2TripleCoordinate {
+    equator: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2EquatorCoordinate>>, // TODO: rename to "shape"
+    edges: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2EdgesCoordinate>>,
+    corners: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2CornersCoordinate>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Square1Phase2Transformation(FlatMoveIndex);
+
+#[derive(Clone, Debug)]
+pub struct Square1Phase2Puzzle {
+    equator_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2EquatorCoordinate>, // TODO: rename to "shape"
+    edges_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2EdgesCoordinate>,
+    corners_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2CornersCoordinate>,
+}
+
+impl Square1Phase2Puzzle {
+    pub fn new() -> Self {
+        let kpuzzle = square1_unbandaged_kpuzzle();
+
+        let equator_puzzle = {
+            let full_generator_moves = move_list_from_vec(vec!["U_SQ_", "D_SQ_", "/"]);
+
+            let start_pattern = square1_shape_kpattern()
+                .apply_alg(&parse_alg!("(0, 0)"))
+                .unwrap(); // TODO: do we need an adjustment for the equator?
+            PhaseCoordinatePuzzle::<KPuzzle, Phase2EquatorCoordinate>::new(
+                kpuzzle.clone(),
+                start_pattern,
+                full_generator_moves,
+            )
+        };
+
+        let reduced_generator_moves = move_list_from_vec(vec!["U_SQ_3", "D_SQ_3", "/"]);
+
+        let edges_puzzle = {
+            let start_pattern = square1_edges_kpattern()
+                .apply_alg(&parse_alg!("(-2, 0)"))
+                .unwrap(); // TODO: do we need an adjustment for the equator?
+            PhaseCoordinatePuzzle::<KPuzzle, Phase2EdgesCoordinate>::new(
+                kpuzzle.clone(),
+                start_pattern,
+                reduced_generator_moves.clone(),
+            )
+        };
+
+        // TODO: reuse the table from edges (with different move remappings)
+        let corners_puzzle = {
+            let start_pattern = square1_corners_kpattern()
+                .apply_alg(&parse_alg!("(1, 0)"))
+                .unwrap(); // TODO: do we need an adjustment for the equator?
+            PhaseCoordinatePuzzle::<KPuzzle, Phase2CornersCoordinate>::new(
+                kpuzzle.clone(),
+                start_pattern,
+                reduced_generator_moves,
+            )
+        };
+
+        Self {
+            equator_puzzle,
+            edges_puzzle,
+            corners_puzzle,
+        }
+    }
+
+    // TODO: report errors for invalid patterns
+    pub fn full_pattern_to_phase_coordinate(
+        &self,
+        pattern: &KPattern,
+    ) -> Result<Square1Phase2TripleCoordinate, PhaseCoordinateConversionError> {
+        let Ok(equator) = self
+            .equator_puzzle
+            .full_pattern_to_phase_coordinate(pattern)
+        else {
+            return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
+        };
+        let Ok(edges) = self.edges_puzzle.full_pattern_to_phase_coordinate(pattern) else {
+            return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
+        };
+        let Ok(corners) = self
+            .corners_puzzle
+            .full_pattern_to_phase_coordinate(pattern)
+        else {
+            return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
+        };
+        Ok(Square1Phase2TripleCoordinate {
+            equator,
+            edges,
+            corners,
+        })
+    }
+}
+
+impl SemiGroupActionPuzzle for Square1Phase2Puzzle {
+    type Pattern = Square1Phase2TripleCoordinate;
+
+    // TODO: use a unified definition of these flat moves.
+    type Transformation = Square1Phase2Transformation;
+
+    fn move_order(
+        &self,
+        r#move: &cubing::alg::Move,
+    ) -> Result<crate::_internal::search::move_count::MoveCount, cubing::kpuzzle::InvalidAlgError>
+    {
+        todo!()
+    }
+
+    fn puzzle_transformation_from_move(
+        &self,
+        r#move: &cubing::alg::Move,
+    ) -> Result<Self::Transformation, cubing::kpuzzle::InvalidAlgError> {
+        todo!()
+    }
+
+    fn do_moves_commute(
+        &self,
+        move1_info: &MoveTransformationInfo<Self>,
+        move2_info: &MoveTransformationInfo<Self>,
+    ) -> bool {
+        todo!()
+    }
+
+    fn pattern_apply_transformation(
+        // TODO: this is a hack to allow `Phase2Puzzle` to access its tables, ideally we would avoid this.
+        // Then again, this might turn out to be necessary for similar high-performance implementations.
+        &self,
+        pattern: &Self::Pattern,
+        transformation_to_apply: &Self::Transformation,
+    ) -> Option<Self::Pattern> {
+        todo!()
+    }
+
+    fn pattern_apply_transformation_into(
+        // TODO: this is a hack to allow `Phase2Puzzle` to access its tables, ideally we would avoid this.
+        // Then again, this might turn out to be necessary for similar high-performance implementations.
+        &self,
+        pattern: &Self::Pattern,
+        transformation_to_apply: &Self::Transformation,
+        into_pattern: &mut Self::Pattern,
+    ) -> bool {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct Square1Phase2PruneTable {}
+
+impl PruneTable<Square1Phase2Puzzle> for Square1Phase2PruneTable {
+    fn new(
+        tpuzzle: Square1Phase2Puzzle,
+        search_api_data: std::sync::Arc<
+            crate::_internal::search::idf_search::idf_search::IDFSearchAPIData<Square1Phase2Puzzle>,
+        >,
+        search_logger: std::sync::Arc<crate::_internal::search::search_logger::SearchLogger>,
+        min_size: Option<usize>,
+    ) -> Self {
+        todo!()
+    }
+
+    fn lookup(&self, pattern: &<Square1Phase2Puzzle as SemiGroupActionPuzzle>::Pattern) -> Depth {
+        todo!()
+    }
+
+    fn extend_for_search_depth(&mut self, search_depth: Depth, approximate_num_entries: usize) {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct Square1Phase2SearchAdaptations {}
 
 /// Explicitly specifies search adaptations for [`Square1Phase2Puzzle`].
 impl SearchAdaptations<Square1Phase2Puzzle> for Square1Phase2SearchAdaptations {
     type PatternValidityChecker = AlwaysValid;
-    type PruneTable = TriplePhaseCoordinatePruneTable<
-        KPuzzle,
-        Phase2ShapeCoordinate,
-        Phase2EdgesCoordinate,
-        Phase2CornersCoordinate,
-    >;
-    type RecursionFilter = Square1Phase2Puzzle;
+    type PruneTable = Square1Phase2PruneTable; // TODO: should this be a no-op?
+    type RecursionFilter = RecursionFilterNoOp; // TODO: Square1Phase2Puzzle;
 }
 
-impl Square1SearchPhase for Square1Phase2Puzzle {}
+impl DefaultSearchAdaptations<Square1Phase2Puzzle> for Square1Phase2Puzzle {
+    type Adaptations = Square1Phase2SearchAdaptations;
+}

--- a/src/rs/scramble/puzzles/square1/phase2.rs
+++ b/src/rs/scramble/puzzles/square1/phase2.rs
@@ -1,28 +1,25 @@
 use cubing::{
-    alg::{parse_alg, parse_move, Alg, Move, QuantumMove},
+    alg::{parse_alg, parse_move, Alg, Move},
     kpuzzle::{KPattern, KPuzzle},
 };
 use lazy_static::lazy_static;
+use std::cmp::max;
 
 use crate::{
     _internal::{
         canonical_fsm::search_generators::{FlatMoveIndex, MoveTransformationInfo},
         puzzle_traits::puzzle_traits::SemiGroupActionPuzzle,
         search::{
-            coordinates::{
-                phase_coordinate_puzzle::{
-                    PhaseCoordinateConversionError, PhaseCoordinateIndex, PhaseCoordinatePuzzle,
-                    SemanticCoordinate,
-                },
-                triple_phase_coordinate_puzzle::{
-                    TriplePhaseCoordinatePruneTable, TriplePhaseCoordinatePuzzle,
-                },
+            coordinates::phase_coordinate_puzzle::{
+                PhaseCoordinateConversionError, PhaseCoordinateIndex, PhaseCoordinatePuzzle,
+                SemanticCoordinate,
             },
             idf_search::search_adaptations::{DefaultSearchAdaptations, SearchAdaptations},
+            indexed_vec::IndexedVec,
             mask_pattern::apply_mask,
             pattern_validity_checker::{AlwaysValid, PatternValidityChecker},
             prune_table_trait::{Depth, PruneTable},
-            recursion_filter_trait::{RecursionFilter, RecursionFilterNoOp},
+            recursion_filter_trait::RecursionFilterNoOp,
         },
     },
     scramble::{
@@ -31,15 +28,13 @@ use crate::{
                 square1_corners_kpattern, square1_edges_kpattern, square1_shape_kpattern,
                 square1_unbandaged_kpuzzle,
             },
-            square1::wedges::{
-                WedgeType, FIRST_WEDGE_INDEX_D, FIRST_WEDGE_INDEX_U, WEDGE_TYPE_LOOKUP,
-            },
+            square1::wedges::{WedgeType, WEDGE_TYPE_LOOKUP},
         },
         scramble_search::move_list_from_vec,
     },
 };
 
-use super::{phase1::restrict_D_move, solve::Square1SearchPhase};
+use super::wedges::{get_phase2_shape_offsets, Square1Phase2Offsets};
 
 struct Phase2Checker;
 
@@ -160,48 +155,24 @@ impl SemanticCoordinate<KPuzzle> for Phase2CornersCoordinate {
     }
 }
 
-// TODO: rename to "shape" and move this above edges and corners
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub(crate) struct Phase2EquatorCoordinate {
-    pub(crate) equator: KPattern,
-}
-
-impl SemanticCoordinate<KPuzzle> for Phase2EquatorCoordinate {
-    fn phase_name() -> &'static str {
-        "Equator (Square-1 → phase 2)"
-    }
-
-    fn try_new(_kpuzzle: &KPuzzle, full_pattern: &KPattern) -> Option<Self> {
-        // TODO: this isn't a full validity check for scramble positions.
-        if !Phase2Checker::is_valid(full_pattern) {
-            return None;
-        }
-
-        let phase_mask = square1_shape_kpattern(); // TODO: Store this with the coordinate lookup?
-        let Ok(masked_pattern) = apply_mask(full_pattern, phase_mask) else {
-            panic!("Mask application failed");
-        };
-
-        Some(Self {
-            equator: masked_pattern,
-        })
-    }
-}
-
 // TODO: generalize this, similar to how `TriplePhaseCoordinatePuzzle` does.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Square1Phase2TripleCoordinate {
-    equator: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2EquatorCoordinate>>, // TODO: rename to "shape"
+    shape: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2ShapeCoordinate>>, // TODO: rename to "shape"
     edges: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2EdgesCoordinate>>,
     corners: PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2CornersCoordinate>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Square1Phase2Transformation(FlatMoveIndex);
+pub struct Square1Phase2Transformation(FlatMoveIndex); // Index into search generators for the shape.
 
 #[derive(Clone, Debug)]
 pub struct Square1Phase2Puzzle {
-    equator_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2EquatorCoordinate>, // TODO: rename to "shape"
+    shape_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2ShapeCoordinate>,
+    shape_to_offsets: IndexedVec<
+        PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2ShapeCoordinate>>,
+        Square1Phase2Offsets,
+    >,
     edges_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2EdgesCoordinate>,
     corners_puzzle: PhaseCoordinatePuzzle<KPuzzle, Phase2CornersCoordinate>,
 }
@@ -229,29 +200,115 @@ fn square1_tuple(U_SQ_amount: i32, D_SQ_amount: i32) -> Alg {
     }
 }
 
+// An optimized representation of a Square-1 move. Note that the set "valid"
+// `i32` values depends on the calling code, as different conventions are needed
+// for different calculations.
+#[derive(Copy, Clone, Debug)]
+#[allow(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
+enum Square1Phase2Move {
+    U_SQ_(i32),
+    D_SQ_(i32),
+    SLASH,
+}
+
+impl From<FlatMoveIndex> for Square1Phase2Move {
+    fn from(value: FlatMoveIndex) -> Self {
+        match value.0 {
+            0 => Square1Phase2Move::U_SQ_(1),
+            1 => Square1Phase2Move::U_SQ_(2),
+            2 => Square1Phase2Move::U_SQ_(3),
+            3 => Square1Phase2Move::U_SQ_(4),
+            4 => Square1Phase2Move::U_SQ_(5),
+            5 => Square1Phase2Move::U_SQ_(6),
+            6 => Square1Phase2Move::U_SQ_(7),
+            7 => Square1Phase2Move::U_SQ_(8),
+            8 => Square1Phase2Move::U_SQ_(9),
+            9 => Square1Phase2Move::U_SQ_(10),
+            10 => Square1Phase2Move::U_SQ_(11),
+            11 => Square1Phase2Move::D_SQ_(1),
+            12 => Square1Phase2Move::D_SQ_(2),
+            13 => Square1Phase2Move::D_SQ_(3),
+            14 => Square1Phase2Move::D_SQ_(4),
+            15 => Square1Phase2Move::D_SQ_(5),
+            16 => Square1Phase2Move::D_SQ_(6),
+            17 => Square1Phase2Move::D_SQ_(7),
+            18 => Square1Phase2Move::D_SQ_(8),
+            19 => Square1Phase2Move::D_SQ_(9),
+            20 => Square1Phase2Move::D_SQ_(10),
+            21 => Square1Phase2Move::D_SQ_(11),
+            22 => Square1Phase2Move::SLASH,
+            _ => panic!("Invalid move"), // TODO: is it faster to just return `SLASH` as the default?
+        }
+    }
+}
+
+// TODO: more type safety
+impl Square1Phase2Move {
+    // Accepts amounts from `0` to `11` (for `U_SQ_` or `D_SQ_` moves).
+    fn to_edge_or_corner_transformation(self) -> Option<FlatMoveIndex> {
+        Some(FlatMoveIndex(match self {
+            Square1Phase2Move::U_SQ_(0) => return None,
+            Square1Phase2Move::U_SQ_(1) => return None,
+            Square1Phase2Move::U_SQ_(2) => return None,
+            Square1Phase2Move::U_SQ_(3) => 0,
+            Square1Phase2Move::U_SQ_(4) => 0,
+            Square1Phase2Move::U_SQ_(5) => 0,
+            Square1Phase2Move::U_SQ_(6) => 1,
+            Square1Phase2Move::U_SQ_(7) => 1,
+            Square1Phase2Move::U_SQ_(8) => 1,
+            Square1Phase2Move::U_SQ_(9) => 2,
+            Square1Phase2Move::U_SQ_(10) => 2,
+            Square1Phase2Move::U_SQ_(11) => 2,
+            Square1Phase2Move::D_SQ_(0) => return None,
+            Square1Phase2Move::D_SQ_(1) => return None,
+            Square1Phase2Move::D_SQ_(2) => return None,
+            Square1Phase2Move::D_SQ_(3) => 3,
+            Square1Phase2Move::D_SQ_(4) => 3,
+            Square1Phase2Move::D_SQ_(5) => 3,
+            Square1Phase2Move::D_SQ_(6) => 4,
+            Square1Phase2Move::D_SQ_(7) => 4,
+            Square1Phase2Move::D_SQ_(8) => 4,
+            Square1Phase2Move::D_SQ_(9) => 5,
+            Square1Phase2Move::D_SQ_(10) => 5,
+            Square1Phase2Move::D_SQ_(11) => 5,
+            Square1Phase2Move::SLASH => 6,
+            _ => panic!("Invalid move"), // TODO: is it faster to just return `None` as the default?
+        }))
+    }
+}
+
 impl Square1Phase2Puzzle {
     pub fn new() -> Self {
         let kpuzzle = square1_unbandaged_kpuzzle();
 
-        let equator_puzzle = {
+        let shape_puzzle = {
             let full_generator_moves = move_list_from_vec(vec!["U_SQ_", "D_SQ_", "/"]);
 
             let start_pattern = square1_shape_kpattern()
                 .apply_alg(&parse_alg!("(0, 0)"))
-                .unwrap(); // TODO: do we need an adjustment for the equator?
-            PhaseCoordinatePuzzle::<KPuzzle, Phase2EquatorCoordinate>::new(
+                .unwrap();
+            PhaseCoordinatePuzzle::<KPuzzle, Phase2ShapeCoordinate>::new(
                 kpuzzle.clone(),
                 start_pattern,
                 full_generator_moves,
             )
         };
 
+        let mut shape_to_offsets = IndexedVec::<
+            PhaseCoordinateIndex<PhaseCoordinatePuzzle<KPuzzle, Phase2ShapeCoordinate>>,
+            Square1Phase2Offsets,
+        >::default();
+        for (_, pattern) in shape_puzzle.data.index_to_semantic_coordinate.iter() {
+            shape_to_offsets.push(get_phase2_shape_offsets(&pattern.shape));
+        }
+
         let reduced_generator_moves = move_list_from_vec(vec!["U_SQ_3", "D_SQ_3", "/"]);
 
         let edges_puzzle = {
             let start_pattern = square1_edges_kpattern()
                 .apply_alg(&parse_alg!("(-2, 0)"))
-                .unwrap(); // TODO: do we need an adjustment for the equator?
+                .unwrap();
             PhaseCoordinatePuzzle::<KPuzzle, Phase2EdgesCoordinate>::new(
                 kpuzzle.clone(),
                 start_pattern,
@@ -263,7 +320,7 @@ impl Square1Phase2Puzzle {
         let corners_puzzle = {
             let start_pattern = square1_corners_kpattern()
                 .apply_alg(&parse_alg!("(1, 0)"))
-                .unwrap(); // TODO: do we need an adjustment for the equator?
+                .unwrap();
             PhaseCoordinatePuzzle::<KPuzzle, Phase2CornersCoordinate>::new(
                 kpuzzle.clone(),
                 start_pattern,
@@ -272,7 +329,8 @@ impl Square1Phase2Puzzle {
         };
 
         Self {
-            equator_puzzle,
+            shape_puzzle,
+            shape_to_offsets,
             edges_puzzle,
             corners_puzzle,
         }
@@ -285,50 +343,33 @@ impl Square1Phase2Puzzle {
         &self,
         pattern: &KPattern,
     ) -> Result<Square1Phase2TripleCoordinate, PhaseCoordinateConversionError> {
-        let orbit_info = &pattern.kpuzzle().data.ordered_orbit_info[0];
-        assert_eq!(orbit_info.name.0, "WEDGES");
+        let offsets = get_phase2_shape_offsets(pattern);
 
-        // Calculate the `U_SQ_`` move amount that needs to be applied to edges/corners to match the lookup table (which is `(1, 0)` away from solved).
-        // Note that the tuples look like Square-1 move tuples, but are in fact not (they both correspond to U moves).
-        #[allow(non_snake_case)]
-        let (edges_U_SQ_amount, corners_U_SQ_amount) =
-            match WEDGE_TYPE_LOOKUP[pattern.get_piece(orbit_info, FIRST_WEDGE_INDEX_U) as usize] {
-                WedgeType::CornerLower => (-2, 1),
-                WedgeType::CornerUpper => (-1, -1),
-                WedgeType::Edge => (0, 0),
-            };
-
-        // TODO: unify with U calculations?
-        #[allow(non_snake_case)]
-        let (edges_D_SQ_amount, corners_D_SQ_amount) =
-            match WEDGE_TYPE_LOOKUP[pattern.get_piece(orbit_info, FIRST_WEDGE_INDEX_D) as usize] {
-                WedgeType::CornerLower => (-2, 1),
-                WedgeType::CornerUpper => (-1, -1),
-                WedgeType::Edge => (0, 0),
-            };
-
-        let Ok(equator) = self
-            .equator_puzzle
-            .full_pattern_to_phase_coordinate(pattern)
-        else {
+        let Ok(shape) = self.shape_puzzle.full_pattern_to_phase_coordinate(pattern) else {
             return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
         };
         let Ok(edges) = self.edges_puzzle.full_pattern_to_phase_coordinate(
             &pattern
-                .apply_alg(&square1_tuple(edges_U_SQ_amount, edges_D_SQ_amount))
+                .apply_alg(&square1_tuple(
+                    offsets.edges_amount_U,
+                    offsets.edges_amount_D,
+                ))
                 .unwrap(),
         ) else {
             return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
         };
         let Ok(corners) = self.corners_puzzle.full_pattern_to_phase_coordinate(
             &pattern
-                .apply_alg(&square1_tuple(corners_U_SQ_amount, corners_D_SQ_amount))
+                .apply_alg(&square1_tuple(
+                    offsets.corners_amount_U,
+                    offsets.corners_amount_D,
+                ))
                 .unwrap(),
         ) else {
             return Err(PhaseCoordinateConversionError::InvalidSemanticCoordinate);
         };
         Ok(Square1Phase2TripleCoordinate {
-            equator,
+            shape,
             edges,
             corners,
         })
@@ -346,14 +387,16 @@ impl SemiGroupActionPuzzle for Square1Phase2Puzzle {
         r#move: &cubing::alg::Move,
     ) -> Result<crate::_internal::search::move_count::MoveCount, cubing::kpuzzle::InvalidAlgError>
     {
-        todo!()
+        self.shape_puzzle.move_order(r#move)
     }
 
     fn puzzle_transformation_from_move(
         &self,
         r#move: &cubing::alg::Move,
     ) -> Result<Self::Transformation, cubing::kpuzzle::InvalidAlgError> {
-        todo!()
+        Ok(Square1Phase2Transformation(
+            self.shape_puzzle.puzzle_transformation_from_move(r#move)?,
+        ))
     }
 
     fn do_moves_commute(
@@ -361,52 +404,144 @@ impl SemiGroupActionPuzzle for Square1Phase2Puzzle {
         move1_info: &MoveTransformationInfo<Self>,
         move2_info: &MoveTransformationInfo<Self>,
     ) -> bool {
-        todo!()
+        let move1_info = self
+            .shape_puzzle
+            .data
+            .search_generators_for_phase_coordinate_puzzle
+            .by_move
+            .get(&move1_info.r#move)
+            .expect("TODO: invalid move lookup?");
+        let move2_info = self
+            .shape_puzzle
+            .data
+            .search_generators_for_phase_coordinate_puzzle
+            .by_move
+            .get(&move2_info.r#move)
+            .expect("TODO: invalid move lookup?");
+        self.shape_puzzle.do_moves_commute(move1_info, move2_info)
     }
 
     fn pattern_apply_transformation(
-        // TODO: this is a hack to allow `Phase2Puzzle` to access its tables, ideally we would avoid this.
-        // Then again, this might turn out to be necessary for similar high-performance implementations.
         &self,
         pattern: &Self::Pattern,
         transformation_to_apply: &Self::Transformation,
     ) -> Option<Self::Pattern> {
-        todo!()
+        // TODO: write down an explanation of the math.
+        // TODO: cache the sharp math in a type-safe table instead of doing it every time.
+
+        let offsets = self.shape_to_offsets.at(pattern.shape);
+
+        let phase2_move = Square1Phase2Move::from(transformation_to_apply.0);
+
+        let edges = {
+            let edges_transformation = match phase2_move {
+                Square1Phase2Move::U_SQ_(amount) => {
+                    Square1Phase2Move::U_SQ_((amount - offsets.edges_amount_U).rem_euclid(12))
+                }
+                Square1Phase2Move::D_SQ_(amount) => {
+                    Square1Phase2Move::D_SQ_((amount - offsets.edges_amount_D).rem_euclid(12))
+                }
+                Square1Phase2Move::SLASH => phase2_move,
+            }
+            .to_edge_or_corner_transformation();
+
+            match edges_transformation {
+                Some(edges_transformation) => self
+                    .edges_puzzle
+                    .pattern_apply_transformation(&pattern.edges, &edges_transformation)
+                    .unwrap_or(pattern.edges),
+                None => pattern.edges,
+            }
+        };
+
+        let corners = {
+            let corners_transformation = match phase2_move {
+                Square1Phase2Move::U_SQ_(amount) => {
+                    Square1Phase2Move::U_SQ_((amount - offsets.corners_amount_U).rem_euclid(12))
+                }
+                Square1Phase2Move::D_SQ_(amount) => {
+                    Square1Phase2Move::D_SQ_((amount - offsets.corners_amount_D).rem_euclid(12))
+                }
+                Square1Phase2Move::SLASH => phase2_move,
+            }
+            .to_edge_or_corner_transformation();
+
+            match corners_transformation {
+                Some(corners_transformation) => self
+                    .corners_puzzle
+                    .pattern_apply_transformation(&pattern.corners, &corners_transformation)
+                    .unwrap_or(pattern.corners),
+                None => pattern.corners,
+            }
+        };
+
+        Some(Self::Pattern {
+            shape: self
+                .shape_puzzle
+                .pattern_apply_transformation(&pattern.shape, &transformation_to_apply.0)?,
+            edges,
+            corners,
+        })
     }
 
     fn pattern_apply_transformation_into(
-        // TODO: this is a hack to allow `Phase2Puzzle` to access its tables, ideally we would avoid this.
-        // Then again, this might turn out to be necessary for similar high-performance implementations.
         &self,
         pattern: &Self::Pattern,
         transformation_to_apply: &Self::Transformation,
         into_pattern: &mut Self::Pattern,
     ) -> bool {
-        todo!()
+        let Some(pattern) = self.pattern_apply_transformation(pattern, transformation_to_apply)
+        else {
+            return false;
+        };
+        into_pattern.shape = pattern.shape;
+        into_pattern.edges = pattern.edges;
+        into_pattern.corners = pattern.corners;
+        true
     }
 }
 
 #[derive(Clone)]
-pub struct Square1Phase2PruneTable {}
+pub struct Square1Phase2PruneTable {
+    tpuzzle: Square1Phase2Puzzle,
+}
 
 impl PruneTable<Square1Phase2Puzzle> for Square1Phase2PruneTable {
     fn new(
         tpuzzle: Square1Phase2Puzzle,
-        search_api_data: std::sync::Arc<
+        _search_api_data: std::sync::Arc<
             crate::_internal::search::idf_search::idf_search::IDFSearchAPIData<Square1Phase2Puzzle>,
         >,
-        search_logger: std::sync::Arc<crate::_internal::search::search_logger::SearchLogger>,
-        min_size: Option<usize>,
+        _search_logger: std::sync::Arc<crate::_internal::search::search_logger::SearchLogger>,
+        _min_size: Option<usize>,
     ) -> Self {
-        todo!()
+        Self { tpuzzle }
     }
 
     fn lookup(&self, pattern: &<Square1Phase2Puzzle as SemiGroupActionPuzzle>::Pattern) -> Depth {
-        todo!()
+        let shape_depth = *self
+            .tpuzzle
+            .shape_puzzle
+            .data
+            .exact_prune_table
+            .at(pattern.shape);
+        let edges_depth = *self
+            .tpuzzle
+            .edges_puzzle
+            .data
+            .exact_prune_table
+            .at(pattern.edges);
+        let corners_depth = *self
+            .tpuzzle
+            .corners_puzzle
+            .data
+            .exact_prune_table
+            .at(pattern.corners);
+        max(shape_depth, max(edges_depth, corners_depth))
     }
 
-    fn extend_for_search_depth(&mut self, search_depth: Depth, approximate_num_entries: usize) {
-        todo!()
+    fn extend_for_search_depth(&mut self, _search_depth: Depth, _approximate_num_entries: usize) {
+        // no-p
     }
 }
 
@@ -416,8 +551,8 @@ pub struct Square1Phase2SearchAdaptations {}
 /// Explicitly specifies search adaptations for [`Square1Phase2Puzzle`].
 impl SearchAdaptations<Square1Phase2Puzzle> for Square1Phase2SearchAdaptations {
     type PatternValidityChecker = AlwaysValid;
-    type PruneTable = Square1Phase2PruneTable; // TODO: should this be a no-op?
-    type RecursionFilter = RecursionFilterNoOp; // TODO: Square1Phase2Puzzle;
+    type PruneTable = Square1Phase2PruneTable;
+    type RecursionFilter = RecursionFilterNoOp;
 }
 
 impl DefaultSearchAdaptations<Square1Phase2Puzzle> for Square1Phase2Puzzle {

--- a/src/rs/scramble/puzzles/square1/solve.rs
+++ b/src/rs/scramble/puzzles/square1/solve.rs
@@ -1,5 +1,6 @@
 // use std::time::{Duration, Instant};
 
+use cubing::alg::parse_alg;
 use cubing::kpuzzle::KPuzzle;
 use cubing::{
     alg::{parse_move, Alg, AlgBuilder, AlgNode, Grouping, Move},
@@ -61,11 +62,7 @@ impl Square1Solver {
             )
             .unwrap();
 
-        let square1_phase2_puzzle: Square1Phase2Puzzle = Square1Phase2Puzzle::new(
-            kpuzzle.clone(),
-            kpuzzle.default_pattern(),
-            generator_moves.clone(),
-        );
+        let square1_phase2_puzzle: Square1Phase2Puzzle = Square1Phase2Puzzle::new();
         let phase2_target_pattern = square1_phase2_puzzle
             .full_pattern_to_phase_coordinate(&kpuzzle.default_pattern())
             .unwrap();

--- a/src/rs/scramble/puzzles/square1/solve.rs
+++ b/src/rs/scramble/puzzles/square1/solve.rs
@@ -117,15 +117,6 @@ impl Square1Solver {
             'phase1_loop: for mut phase1_solution in phase1_search {
                 found_phase1_solutions += 1;
                 // phase1_cumulative_time += Instant::now() - phase1_start_time;
-                let Ok(phase2_start_pattern) =
-                    self.square1_phase2_puzzle.full_pattern_to_phase_coordinate(
-                        &pattern.apply_alg(&phase1_solution).unwrap(),
-                    )
-                else {
-                    return Err(SearchError {
-                        description: "Could not convert pattern into phase 2 coordinate".to_owned(),
-                    });
-                };
                 // TODO: Push the candidate check into a trait for `IDFSearch`.
                 while let Some(cubing::alg::AlgNode::MoveNode(r#move)) =
                     phase1_solution.nodes.last()
@@ -145,6 +136,15 @@ impl Square1Solver {
                 checked_phase1_solutions += 1;
                 // num_phase2_starts += 1;
                 // let phase2_start_time = Instant::now();
+                let Ok(phase2_start_pattern) =
+                    self.square1_phase2_puzzle.full_pattern_to_phase_coordinate(
+                        &pattern.apply_alg(&phase1_solution).unwrap(),
+                    )
+                else {
+                    return Err(SearchError {
+                        description: "Could not convert pattern into phase 2 coordinate".to_owned(),
+                    });
+                };
                 let phase2_solution = self
                     .phase2_idfs
                     .search(

--- a/src/rs/scramble/puzzles/square1/solve.rs
+++ b/src/rs/scramble/puzzles/square1/solve.rs
@@ -1,6 +1,5 @@
 // use std::time::{Duration, Instant};
 
-use cubing::alg::parse_alg;
 use cubing::kpuzzle::KPuzzle;
 use cubing::{
     alg::{parse_move, Alg, AlgBuilder, AlgNode, Grouping, Move},

--- a/src/rs/scramble/puzzles/square1/wedges.rs
+++ b/src/rs/scramble/puzzles/square1/wedges.rs
@@ -1,6 +1,6 @@
 use cubing::kpuzzle::KPattern;
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub(crate) enum WedgeType {
     CornerLower,
     CornerUpper,

--- a/src/rs/scramble/puzzles/square1/wedges.rs
+++ b/src/rs/scramble/puzzles/square1/wedges.rs
@@ -1,3 +1,5 @@
+use cubing::kpuzzle::KPattern;
+
 #[derive(PartialEq, Eq)]
 pub(crate) enum WedgeType {
     CornerLower,
@@ -6,9 +8,6 @@ pub(crate) enum WedgeType {
 }
 
 pub(crate) const NUM_WEDGES: u8 = 24;
-
-pub(crate) const FIRST_WEDGE_INDEX_U: u8 = 0;
-pub(crate) const FIRST_WEDGE_INDEX_D: u8 = 12;
 
 pub(crate) const WEDGE_TYPE_LOOKUP: [WedgeType; NUM_WEDGES as usize] = [
     WedgeType::CornerLower,
@@ -36,3 +35,45 @@ pub(crate) const WEDGE_TYPE_LOOKUP: [WedgeType; NUM_WEDGES as usize] = [
     WedgeType::CornerLower,
     WedgeType::CornerUpper,
 ];
+
+const FIRST_WEDGE_INDEX_U: u8 = 0;
+const FIRST_WEDGE_INDEX_D: u8 = 12;
+
+// The move amount (for `U_SQ_` or `D_SQ_`) that needs to be applied to
+// edges/corners to match the lookup table reference shape (which is `(1, 0)`
+// away from solved).
+#[derive(Debug, Clone)]
+#[allow(non_snake_case)]
+pub(crate) struct Square1Phase2Offsets {
+    pub(crate) edges_amount_U: i32,
+    pub(crate) edges_amount_D: i32,
+    pub(crate) corners_amount_U: i32,
+    pub(crate) corners_amount_D: i32,
+}
+
+fn get_phase2_shape_offset_single_side(pattern: &KPattern, wedge_index: u8) -> (i32, i32) {
+    let orbit_info = &pattern.kpuzzle().data.ordered_orbit_info[0];
+    assert_eq!(orbit_info.name.0, "WEDGES");
+
+    match WEDGE_TYPE_LOOKUP[pattern.get_piece(orbit_info, wedge_index) as usize] {
+        WedgeType::CornerLower => (-2, 1),
+        WedgeType::CornerUpper => (-1, -1),
+        WedgeType::Edge => (0, 0),
+    }
+}
+
+pub(crate) fn get_phase2_shape_offsets(pattern: &KPattern) -> Square1Phase2Offsets {
+    // Note that the tuples look like Square-1 move tuples, but are in fact not (they both correspond to U moves).
+    #[allow(non_snake_case)]
+    let (edges_amount_U, corners_amount_U) =
+        get_phase2_shape_offset_single_side(pattern, FIRST_WEDGE_INDEX_U);
+    #[allow(non_snake_case)]
+    let (edges_amount_D, corners_amount_D) =
+        get_phase2_shape_offset_single_side(pattern, FIRST_WEDGE_INDEX_D);
+    Square1Phase2Offsets {
+        edges_amount_U,
+        edges_amount_D,
+        corners_amount_U,
+        corners_amount_D,
+    }
+}

--- a/src/rs/scramble/puzzles/square1/wedges.rs
+++ b/src/rs/scramble/puzzles/square1/wedges.rs
@@ -7,6 +7,9 @@ pub(crate) enum WedgeType {
 
 pub(crate) const NUM_WEDGES: u8 = 24;
 
+pub(crate) const FIRST_WEDGE_INDEX_U: u8 = 0;
+pub(crate) const FIRST_WEDGE_INDEX_D: u8 = 12;
+
 pub(crate) const WEDGE_TYPE_LOOKUP: [WedgeType; NUM_WEDGES as usize] = [
     WedgeType::CornerLower,
     WedgeType::CornerUpper,


### PR DESCRIPTION
This reduces initialization from over 5 seconds to about 1.

Before:

```shell
# 5.5 seconds
cargo build --release && time ./target/release/twsearch scramble --amount 1 sq1

# 9.9 seconds
cargo build --release && time ./target/release/twsearch scramble --amount 100 sq1
```

After:

```shell
# 0.95 seconds
cargo build --release && time ./target/release/twsearch scramble --amount 1 sq1

# 5.7 seconds
cargo build --release && time ./target/release/twsearch scramble --amount 100 sq1
```

We can still gain more — https://github.com/cubing/twsearch/issues/101 is for that.

