### PR TITLE
Implement resumable search using a continuation condition option for `IterativeDeepeningSearch`.

### DIFF
--- a/script/build-wasm-package.ts
+++ b/script/build-wasm-package.ts
@@ -63,7 +63,7 @@ assert(wasmSize > 32 * KiB); // Make sure the file exists and has some contents.
  * - See https://github.com/cubing/twsearch/issues/37 for an issue about
  *   decreasing the WASM build size directly.
  */
-assert(secondsToDownloadUsing3G(wasmSize) < 6.5);
+assert(secondsToDownloadUsing3G(wasmSize) < 7);
 
 await mkdir(distDir, { recursive: true });
 

--- a/src/cpp/rs/wrapper_options.rs
+++ b/src/cpp/rs/wrapper_options.rs
@@ -70,6 +70,12 @@ impl SetCppArgs for CommonSearchArgs {
         set_optional_arg("--mindepth", &self.min_depth.map(|o| o.0));
         set_optional_arg("-m", &self.max_depth.map(|o| o.0));
         set_optional_arg("--startprunedepth", &self.start_prune_depth.map(|o| o.0));
+        if self.continue_after.is_some() {
+            panic!("Continuation is unsupported.")
+        }
+        if self.continue_at.is_some() {
+            panic!("Continuation is unsupported.")
+        }
         self.performance_args.set_cpp_args();
     }
 }

--- a/src/rs/_cli/commands/cli_search.rs
+++ b/src/rs/_cli/commands/cli_search.rs
@@ -24,7 +24,7 @@ pub fn cli_search(search_command_args: SearchCommandArgs) -> Result<(), CommandE
             solution.nodes.len()
         )
     }
-    println!(
+    eprintln!(
         "// Entire search duration: {:?}",
         instant::Instant::now() - search_start_time
     );

--- a/src/rs/_internal/cli/args.rs
+++ b/src/rs/_internal/cli/args.rs
@@ -31,6 +31,8 @@ pub struct TwsearchArgs {
     pub command: CliCommand,
 }
 
+// Clippy warns on only 200 bytes of difference between variants, but this enum is not memory usage sensitive. (TODO: can we have it warn us on a much larger difference?)
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum CliCommand {
     /// Run a single search.
@@ -92,6 +94,16 @@ pub struct CommonSearchArgs {
     /// Stop solution search at this depth.
     #[clap(long/* , visible_alias = "maxdepth" */)]
     pub max_depth: Option<Depth>,
+
+    /// Continue (or start) search after this alg.
+    /// If the alg is a valid solution, it will be skipped.
+    #[clap(long, group = "continue_search")]
+    pub continue_after: Option<String>, // TODO: `FromStr` is implemented for `Alg` by `cubing.rs`, why doesn't `Option<Alg>` work?
+
+    /// Continue (or start) search at this alg.
+    /// If the alg is a valid solution, it will be the first one returned.
+    #[clap(long, group = "continue_search")]
+    pub continue_at: Option<String>, // TODO: `FromStr` is implemented for `Alg` by `cubing.rs`, why doesn't `Option<Alg>` work?
 
     #[command(flatten)]
     pub performance_args: PerformanceArgs,


### PR DESCRIPTION
Addresses https://github.com/cubing/twsearch/issues/143

Usage example:

```shell
# fish
cargo run --release -- \
  search \
  --verbosity info \
  --generator-moves U,F,R \
  --scramble-alg "R F U' F U L2 F' R' U' L' U' x' y2" \
  --min-num-solutions 10 \
  samples/json/2x2x2/2x2x2.kpuzzle.json | tee /tmp/solutions.json

# The following sequence of commands can be run multiple times.
set RESUME_AFTER_SOLUTION (tail -n 1 /tmp/solutions.json | sed "s#//.*##")
echo -e "\nResuming…" >> /tmp/solutions.json
cargo run --release -- \
  search \
  --verbosity info \
  --generator-moves U,F,R \
  --scramble-alg "R F U' F U L2 F' R' U' L' U' x' y2" \
  --min-num-solutions 10 \
  --continue-after $RESUME_AFTER_SOLUTION \
  samples/json/2x2x2/2x2x2.kpuzzle.json | tee -a /tmp/solutions.json
```

Implementing an upper bound for the search in a similar manner should be simple, and will enable sharding (and therefore multi-threading).

Also note that this implements the option for `IterativeDeepeningSearch`, but does not yet use it to produce multiple solutions. That will be in a folllow-up.