### PR TITLE
Implement backtracking for multi_phase_search, set max depth for 4x4x4 phase3 solver

### DIFF
--- a/src/cli/src/serve/serve.rs
+++ b/src/cli/src/serve/serve.rs
@@ -150,7 +150,7 @@ async fn solve_pattern(
                 .unwrap()
         }
     };
-    let mut search = <IterativeDeepeningSearch<KPuzzle>>::new_with_hash_prune_table(
+    let search = <IterativeDeepeningSearch<KPuzzle>>::new_with_hash_prune_table(
         immutable_search_data,
         StoredSearchAdaptations::default(),
         Default::default(),

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "twips"
 version.workspace = true
-license.workspace = true
 edition.workspace = true
 description = "Twizzle Pattern Searcher — Twisty puzzle search library"
 repository = "https://github.com/cubing/twips"
+license.workspace = true
 
-[features]
-default = []
-simd = ["cubing/simd"]
+[lib]
+crate-type = ["rlib"]
+path = "./mod.rs"
+
+[[bin]]
+name = "bench4x4x4"
+path = "bin/bench4x4x4.rs"
 
 [dependencies]
 ascii = "1.1.0"
@@ -22,12 +26,12 @@ instant = { version = "0.1.13", features = ["wasm-bindgen"] }
 multiset = "0.0.5"
 num-integer = "0.1.46"
 rand = "0.9.3"
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-sha2 = "0.10.9"
-serde_json = "1.0.145"
-thousands = "0.2.0"
 rand_core = "0.9.3"
+serde = { version = "1.0.228", features = ["derive", "rc"] }
+serde_json = "1.0.145"
+sha2 = "0.10.9"
+thousands = "0.2.0"
 
-[lib]
-path = "./mod.rs"
-crate-type = ["rlib"]
+[features]
+default = []
+simd = ["cubing/simd"]

--- a/src/lib/_internal/search/iterative_deepening/individual_search.rs
+++ b/src/lib/_internal/search/iterative_deepening/individual_search.rs
@@ -103,7 +103,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> IndividualSearchData<TPuzzle> {
     /// Note that search is pull-based. You must call `.next()` (or invoke
     /// something that does) on the return value for the search to begine.
     pub fn new(
-        search: &mut IterativeDeepeningSearch<TPuzzle>,
+        search: &IterativeDeepeningSearch<TPuzzle>,
         search_pattern: &TPuzzle::Pattern,
         mut individual_search_options: IndividualSearchOptions,
         individual_search_adaptations: IndividualSearchAdaptations<TPuzzle>,

--- a/src/lib/_internal/search/iterative_deepening/iterative_deepening_search.rs
+++ b/src/lib/_internal/search/iterative_deepening/iterative_deepening_search.rs
@@ -1,4 +1,4 @@
-use std::{cmp::max, sync::Arc};
+use std::{cell::RefCell, cmp::max, sync::Arc};
 
 use crate::_internal::{
     canonical_fsm::{
@@ -40,7 +40,7 @@ enum SearchRecursionResult {
 }
 
 pub struct IterativeDeepeningSearchCursor<'a, TPuzzle: SemiGroupActionPuzzle = KPuzzle> {
-    search: &'a mut IterativeDeepeningSearch<TPuzzle>,
+    search: &'a IterativeDeepeningSearch<TPuzzle>,
     individual_search_data: IndividualSearchData<TPuzzle>,
 }
 
@@ -138,7 +138,7 @@ pub struct IterativeDeepeningSearch<TPuzzle: SemiGroupActionPuzzle = KPuzzle> {
     pub immutable_search_data: Arc<ImmutableSearchData<TPuzzle>>,
     pub stored_search_adaptations: StoredSearchAdaptations<TPuzzle>,
     // We require a prune table to avoid accidentally constructing a super slow search. The caller can explicitly pass in a useless prune table if they want.
-    pub prune_table: Box<dyn PruneTable<TPuzzle>>,
+    pub prune_table: RefCell<Box<dyn PruneTable<TPuzzle>>>,
 }
 
 #[derive(Default)]
@@ -189,14 +189,14 @@ impl<TPuzzle: SemiGroupActionPuzzle> IterativeDeepeningSearch<TPuzzle> {
         Self {
             immutable_search_data: immutable_search_data.into(),
             stored_search_adaptations,
-            prune_table,
+            prune_table: RefCell::new(prune_table),
         }
     }
 
     /// Note that search is pull-based. You must call `.next()` on the return
     /// value (or invoke something that does) for the search to begin/continue.
     pub fn search<'a>(
-        &'a mut self,
+        &'a self,
         search_pattern: &TPuzzle::Pattern,
         individual_search_options: IndividualSearchOptions,
         individual_search_adaptations: IndividualSearchAdaptations<TPuzzle>,
@@ -223,13 +223,13 @@ impl<TPuzzle: SemiGroupActionPuzzle> IterativeDeepeningSearch<TPuzzle> {
     /// Note that search is pull-based. You must call `.next()` (or invoke
     /// something that does) on the return value for the search to begine.
     pub fn owned_search(
-        mut self,
+        self,
         search_pattern: &TPuzzle::Pattern,
         individual_search_options: IndividualSearchOptions,
         individual_search_adaptations: IndividualSearchAdaptations<TPuzzle>,
     ) -> OwnedIterativeDeepeningSearchCursor<TPuzzle> {
         let individual_search_data = IndividualSearchData::new(
-            &mut self,
+            &self,
             search_pattern,
             individual_search_options,
             individual_search_adaptations,
@@ -242,7 +242,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> IterativeDeepeningSearch<TPuzzle> {
 
     // TODO: ideally the return should be represented by a fallible iterator (since it can fail caller-provided input deep in the stack).
     fn search_internal(
-        &mut self,
+        &self,
         individual_search_data: &mut IndividualSearchData<TPuzzle>,
     ) -> Option<Alg> {
         // TODO: the `min_num_solutions` semantics need a redesign throughout all of `twips`.
@@ -304,7 +304,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> IterativeDeepeningSearch<TPuzzle> {
                 .search_logger
                 .write_info("----------------");
 
-            self.prune_table.extend_for_search_depth(
+            self.prune_table.borrow_mut().extend_for_search_depth(
                 remaining_depth,
                 individual_search_data
                     .recursive_work_tracker
@@ -388,7 +388,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> IterativeDeepeningSearch<TPuzzle> {
                 continuation_condition,
             );
         }
-        let prune_table_depth = self.prune_table.lookup(current_pattern);
+        let prune_table_depth = self.prune_table.borrow().lookup(current_pattern);
         if prune_table_depth > remaining_depth + Depth(1) {
             return SearchRecursionResult::ContinueSearchingExcludingCurrentMoveClass;
         }

--- a/src/lib/bin/bench4x4x4.rs
+++ b/src/lib/bin/bench4x4x4.rs
@@ -1,0 +1,29 @@
+use std::{str::FromStr, time::Instant};
+
+use twips::scramble::{derive_scramble_for_event, DerivationSeed, Event};
+
+// Generated randomly with `DerivationSeed::from_thread_rng()`
+const SEEDS: &[&str] = &[
+    "67ffb1b6264c1fb98a30d22b4024d18099cc1678aaa0d995ec5b94e4723582ae",
+    "67ff335173b8de81e84d6f7cb0c73a468555c080727a41c315d12053fc72f072",
+    "67ff421e3036174cd3d05f29ca5eb776da3b6e1f09042776d6a264ed051e9c86",
+    "67ff6da8e32be39c519639824f7268097a2cf838cadc4e2bbd375f41bb331422",
+    "67ff48d8d567c3ef7671e2d325ebf9d1ef88f1e0b5dccd2449ac8e97d6755383",
+    "67ff4ac6407c3ee6343e4d346f7cf831087590bdce7ef4e5af7cbdbc5ecf1497",
+];
+
+fn main() {
+    let now = Instant::now();
+
+    for seed in SEEDS {
+        let derivation_seed = DerivationSeed::from_str(seed).unwrap();
+
+        let now = Instant::now();
+
+        let scramble =
+            derive_scramble_for_event(Event::Cube4x4x4Speedsolving, derivation_seed).unwrap();
+        println!("({:?}) {scramble}", now.elapsed());
+    }
+
+    println!("Total time: {:?}", now.elapsed());
+}

--- a/src/lib/experimental_lib_api/constant_alg_search_phase.rs
+++ b/src/lib/experimental_lib_api/constant_alg_search_phase.rs
@@ -15,7 +15,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> SearchPhase<TPuzzle> for ConstantAlgSearchP
     }
 
     fn solutions(
-        &mut self,
+        &self,
         _phase_search_pattern: &<TPuzzle as SemiGroupActionPuzzle>::Pattern,
     ) -> Result<Box<dyn Iterator<Item = Alg>>, SearchError> {
         Ok(Box::new(vec![self.alg.clone()].into_iter()))

--- a/src/lib/experimental_lib_api/derived_puzzle_search_phase.rs
+++ b/src/lib/experimental_lib_api/derived_puzzle_search_phase.rs
@@ -60,7 +60,7 @@ where
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &TSourcePuzzle::Pattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {
         let Some(search_pattern) = self.derived_puzzle.derive_pattern(phase_search_pattern) else {
@@ -85,7 +85,7 @@ where
     TDerivedPuzzle::Transformation: Send + Sync,
 {
     pub fn solutions_using_individual_search_adaptations(
-        &mut self,
+        &self,
         phase_search_pattern: &TSourcePuzzle::Pattern,
         individual_search_adaptations: IndividualSearchAdaptations<TDerivedPuzzle>,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {

--- a/src/lib/experimental_lib_api/kpuzzle_simple_mask_phase.rs
+++ b/src/lib/experimental_lib_api/kpuzzle_simple_mask_phase.rs
@@ -124,7 +124,7 @@ impl SearchPhase<KPuzzle> for KPuzzleSimpleMaskPhase {
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &KPattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {
         let Ok(masked_pattern) = apply_mask(phase_search_pattern, &self.mask) else {

--- a/src/lib/experimental_lib_api/multi_phase_search.rs
+++ b/src/lib/experimental_lib_api/multi_phase_search.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{iter, marker::PhantomData};
 
 use cubing::alg::{Alg, AlgNode, Pause};
 
@@ -40,11 +40,21 @@ impl<TPuzzle: SemiGroupActionPuzzle> MultiPhaseSearch<TPuzzle> {
     }
 
     pub fn chain_first_solution_for_each_phase(
-        &mut self,
+        &self,
         search_pattern: &TPuzzle::Pattern,
     ) -> Result<Alg, SearchError> {
         let mut current_solution: Option<Alg> = None;
-        for phase in self.phases.iter_mut() {
+
+        // Need to use this to build the vec as Box<...> is not Clone
+        let mut phases_solutions_iter: Vec<Option<Box<dyn Iterator<Item = Alg>>>> =
+            iter::repeat_with(|| None).take(self.phases.len()).collect();
+        let mut phases_current_solutions = vec![None; self.phases.len()];
+
+        let mut idx = 0;
+        let phases_length = self.phases.len();
+        while idx < phases_length {
+            let phase = &self.phases[idx];
+
             // TODO: avoid formatting unless it will be printed.
             self.options
                 .search_logger
@@ -54,11 +64,10 @@ impl<TPuzzle: SemiGroupActionPuzzle> MultiPhaseSearch<TPuzzle> {
                 current_solution.clone().unwrap_or_default()
             ));
 
-            // TODO: can we avoid clones?
             let Some(phase_search_pattern) = apply_flat_alg(
                 &self.tpuzzle,
-                &search_pattern.clone(),
-                &current_solution.clone().unwrap_or_default(),
+                search_pattern,
+                current_solution.as_ref().unwrap_or(&Alg::default()),
             ) else {
                 return Err(SearchError {
                     description: format!(
@@ -73,14 +82,52 @@ impl<TPuzzle: SemiGroupActionPuzzle> MultiPhaseSearch<TPuzzle> {
                 "phase_search_pattern: {:#?}",
                 phase_search_pattern
             ));
-            let Some(phase_solution) = phase.solutions(&phase_search_pattern)?.next() else {
-                return Err(SearchError {
-                    description: format!(
-                        "Could not find a solution for phase: {}",
-                        phase.phase_name()
-                    ),
+
+            let mut phase_solutions = phase.solutions(&phase_search_pattern)?;
+
+            let Some(phase_solution) = phase_solutions.next() else {
+                self.options.search_logger.write_info(&format!(
+                              "Could not find solutions for phase: {}. Trying the next solution from previous phase.",
+                             phase.phase_name()
+                          ));
+
+                // Roll back the state to the previous phase, and try the next solution found
+                let mut prev_phase_next_solution = None;
+                while idx > 0 && prev_phase_next_solution.is_none() {
+                    prev_phase_next_solution = phases_solutions_iter[idx - 1]
+                        .as_mut()
+                        .and_then(|v| v.next());
+                    phases_current_solutions[idx - 1] = prev_phase_next_solution.clone();
+
+                    phases_current_solutions[idx] = None;
+                    phases_solutions_iter[idx] = None;
+
+                    idx -= 1;
+                }
+
+                if prev_phase_next_solution.is_none() {
+                    return Err(SearchError {
+                        description: "Could not find a solution".to_string(),
+                    });
+                }
+
+                // Cloning everything is not optimal, but this doesn't happen really often so should be fine
+                current_solution = Some(Alg {
+                    nodes: phases_current_solutions
+                        .iter()
+                        .take_while(|n| n.is_some())
+                        .flatten()
+                        .flat_map(|v| v.nodes.clone())
+                        .collect(),
                 });
+
+                idx += 1;
+
+                continue;
             };
+
+            phases_solutions_iter[idx] = Some(phase_solutions);
+            phases_current_solutions[idx] = Some(phase_solution.clone());
 
             // TODO: implement pause riffling.
             current_solution = match current_solution.take() {
@@ -97,9 +144,11 @@ impl<TPuzzle: SemiGroupActionPuzzle> MultiPhaseSearch<TPuzzle> {
                     .concat(),
                 }),
                 None => Some(Alg {
-                    nodes: [phase_solution.nodes].concat(),
+                    nodes: phase_solution.nodes,
                 }),
             };
+
+            idx += 1;
         }
         Ok(current_solution.expect("No phase solutions?"))
     }

--- a/src/lib/experimental_lib_api/search_phase.rs
+++ b/src/lib/experimental_lib_api/search_phase.rs
@@ -10,7 +10,7 @@ pub trait SearchPhase<TPuzzle: SemiGroupActionPuzzle>: Send + Sync {
     fn phase_name(&self) -> &str;
 
     fn solutions<'a>(
-        &'a mut self,
+        &'a self,
         phase_search_pattern: &TPuzzle::Pattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + 'a>, SearchError>;
 

--- a/src/lib/scramble/mod.rs
+++ b/src/lib/scramble/mod.rs
@@ -16,8 +16,8 @@ pub use event::{Event, EventError};
 
 mod random_scramble_for_event;
 pub use random_scramble_for_event::{
-    experimental_scramble_finder_filter_and_or_search, random_scramble_for_event,
-    solve_known_puzzle, ExperimentalFilterAndOrSearchOptions,
+    derive_scramble_for_event, experimental_scramble_finder_filter_and_or_search,
+    random_scramble_for_event, solve_known_puzzle, ExperimentalFilterAndOrSearchOptions,
 };
 
 mod derive_scramble_for_event;

--- a/src/lib/scramble/puzzles/baby_fto.rs
+++ b/src/lib/scramble/puzzles/baby_fto.rs
@@ -155,7 +155,7 @@ impl SolvingBasedScrambleFinder for BabyFTOScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &NoScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/cube2x2x2_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/cube2x2x2_scramble_finder.rs
@@ -130,7 +130,7 @@ impl SolvingBasedScrambleFinder for Cube2x2x2ScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/cube4x4x4/cube4x4x4_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/cube4x4x4/cube4x4x4_scramble_finder.rs
@@ -121,7 +121,7 @@ impl SolvingBasedScrambleFinder for Cube4x4x4ScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/cube4x4x4/phase2.rs
+++ b/src/lib/scramble/puzzles/cube4x4x4/phase2.rs
@@ -203,7 +203,7 @@ impl SearchPhase<KPuzzle> for Cube4x4x4Phase2Search {
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &KPattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {
         let phase_search_pattern_owned = phase_search_pattern.clone();

--- a/src/lib/scramble/puzzles/cube4x4x4/phase3.rs
+++ b/src/lib/scramble/puzzles/cube4x4x4/phase3.rs
@@ -23,6 +23,7 @@ use crate::{
                     IterativeDeepeningSearch,
                 },
             },
+            prune_table_trait::Depth,
             search_logger::{SearchLogger, VerbosityLevel},
         },
     },
@@ -448,8 +449,7 @@ impl Default for Cube4x4x4Phase3Search {
                 cube4x4x4_phase3_puzzle,
                 phase3_iterative_deepening_search,
                 IndividualSearchOptions {
-                    // TODO: Use this max depth once `MultiPhaseSearch` can handle it.
-                    // max_depth_exclusive: Some(Depth(14)),
+                    max_depth_exclusive: Some(Depth(15)),
                     ..Default::default()
                 },
             );
@@ -465,7 +465,7 @@ impl SearchPhase<KPuzzle> for Cube4x4x4Phase3Search {
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &KPattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {
         self.derived_puzzle_search_phase

--- a/src/lib/scramble/puzzles/cube4x4x4/phase4.rs
+++ b/src/lib/scramble/puzzles/cube4x4x4/phase4.rs
@@ -104,7 +104,7 @@ impl SearchPhase<KPuzzle> for Cube4x4x4Phase4Search {
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &KPattern,
     ) -> Result<Box<dyn Iterator<Item = Alg>>, SearchError> {
         let Some(pattern) = self

--- a/src/lib/scramble/puzzles/kilominx/kilominx_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/kilominx/kilominx_scramble_finder.rs
@@ -177,7 +177,7 @@ impl SolvingBasedScrambleFinder for KilominxScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/kilominx/phase1.rs
+++ b/src/lib/scramble/puzzles/kilominx/phase1.rs
@@ -42,7 +42,7 @@ impl SearchPhase<KPuzzle> for KilominxPhase1Search {
     }
 
     fn solutions(
-        &mut self,
+        &self,
         phase_search_pattern: &KPattern,
     ) -> Result<Box<dyn Iterator<Item = Alg> + '_>, SearchError> {
         let back_pieces_owned = self.back_pieces.clone(); // TODO: avoid a clone

--- a/src/lib/scramble/puzzles/megaminx/megaminx_solver.rs
+++ b/src/lib/scramble/puzzles/megaminx/megaminx_solver.rs
@@ -159,7 +159,7 @@ impl SolvingBasedScrambleFinder for MegaminxSolver {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, crate::_internal::errors::SearchError> {

--- a/src/lib/scramble/puzzles/pyraminx_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/pyraminx_scramble_finder.rs
@@ -140,7 +140,7 @@ impl SolvingBasedScrambleFinder for PyraminxScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/skewb_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/skewb_scramble_finder.rs
@@ -170,7 +170,7 @@ impl SolvingBasedScrambleFinder for SkewbScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/puzzles/square1/square1_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/square1/square1_scramble_finder.rs
@@ -327,7 +327,7 @@ impl SolvingBasedScrambleFinder for Square1ScrambleFinder {
     }
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         _scramble_options: &Self::ScrambleOptions,
     ) -> Result<cubing::alg::Alg, crate::_internal::errors::SearchError> {

--- a/src/lib/scramble/puzzles/two_phase_3x3x3_scramble_finder.rs
+++ b/src/lib/scramble/puzzles/two_phase_3x3x3_scramble_finder.rs
@@ -146,7 +146,7 @@ impl SolvingBasedScrambleFinder for TwoPhase3x3x3ScrambleFinder {
 
     // TODO: handle all `unwrap()`s.
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &KPattern,
         scramble_options: &TwoPhase3x3x3ScrambleOptions,
     ) -> Result<Alg, SearchError> {

--- a/src/lib/scramble/random_scramble_for_event.rs
+++ b/src/lib/scramble/random_scramble_for_event.rs
@@ -378,7 +378,7 @@ pub fn experimental_scramble_finder_filter_and_or_search(
 
 fn solve_using_scramble_finder<T: SolvingBasedScrambleFinder<TPuzzle = KPuzzle> + GetKPuzzle>(
     scramble_setup_alg: &Alg,
-    mut scramble_finder: T,
+    scramble_finder: T,
     scramble_options: &T::ScrambleOptions,
 ) -> Result<Option<Alg>, TwipsError> {
     let pattern = scramble_finder

--- a/src/lib/scramble/scramble_finder/solving_based_scramble_finder.rs
+++ b/src/lib/scramble/scramble_finder/solving_based_scramble_finder.rs
@@ -25,7 +25,7 @@ pub trait SolvingBasedScrambleFinder: ScrambleFinder {
     ) -> <<Self as ScrambleFinder>::TPuzzle as SemiGroupActionPuzzle>::Pattern;
 
     fn solve_pattern(
-        &mut self,
+        &self,
         pattern: &<<Self as ScrambleFinder>::TPuzzle as SemiGroupActionPuzzle>::Pattern,
         scramble_options: &Self::ScrambleOptions,
     ) -> Result<Alg, SearchError>;

--- a/src/lib/scramble/scramble_search.rs
+++ b/src/lib/scramble/scramble_search.rs
@@ -75,7 +75,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> FilteredSearch<TPuzzle> {
 
     /// This function depends on the caller to pass parameters that will always result in an alg.
     pub fn solve(
-        &mut self,
+        &self,
         scramble_pattern: &TPuzzle::Pattern,
         min_scramble_moves: Option<MoveCount>,
     ) -> Option<Alg> {
@@ -94,7 +94,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> FilteredSearch<TPuzzle> {
 
     /// This function depends on the caller to pass parameters that will always result in an alg.
     pub fn solve_or_error(
-        &mut self,
+        &self,
         scramble_pattern: &TPuzzle::Pattern,
         min_scramble_moves: Option<MoveCount>,
     ) -> Result<Alg, SearchError> {
@@ -108,7 +108,7 @@ impl<TPuzzle: SemiGroupActionPuzzle> FilteredSearch<TPuzzle> {
 
     /// This function depends on the caller to pass parameters that will always result in an alg.
     pub fn generate_scramble(
-        &mut self,
+        &self,
         scramble_pattern: &TPuzzle::Pattern,
         min_scramble_moves: Option<MoveCount>,
     ) -> Alg {


### PR DESCRIPTION
Switch the `SearchPhase` trait solutions to not take a mutable reference, and instead use a `RefCell` to get interior mutability for increasing the size of the prune table.

Also sets the `max_depth_exclusive` to 15 for the 4x4x4 phase3.
From what I benchmarked, setting it to 14, as it was in the comment makes it take several times longer to solve. Increasing it to 15 fixes it.

This is basically a ~1% regression for scrambles that were finding a solution without backtracking, due to the introduction of the RefCell, but a improvement of 10-35% for the rest. The benchmark code I used is in `src/lib/bin/bench4x4x4.rs`
